### PR TITLE
Reset controls when changing layout tabs

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -494,8 +494,10 @@ namespace Rutland.PrintFileMaker
 
         private void tabLayoutType_SelectedIndexChanged(object sender, EventArgs e)
         {
+            this.ClearAll();
             this.cmbSelect5x5Layout.SelectedIndex = -1;
             this.CbLayoutStyle.SelectedIndex = -1;
+            this.CbLayoutStyleRoulette.SelectedIndex = -1;
             this.LayoutType = (LayoutType)Enum.ToObject(typeof(LayoutType), tabLayoutType.SelectedIndex);
 
             switch (LayoutType)


### PR DESCRIPTION
## Summary
- clear all panels when switching layout tabs
- reset roulette layout combobox when tab changes

## Testing
- `dotnet test` *(fails: command not found)*