### PR TITLE
Add double-image option for ThirdSheet

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -39,6 +39,7 @@
             this.pnlTop = new System.Windows.Forms.Panel();
             this.CbLayoutStyle = new System.Windows.Forms.ComboBox();
             this.lblSelectTsLayout = new System.Windows.Forms.Label();
+            this.rbDoubleImages = new System.Windows.Forms.RadioButton();
             this.TabFiveByFive = new System.Windows.Forms.TabPage();
             this.TabNewRoulette = new System.Windows.Forms.TabPage();
             this.TabNewRoulette.Location = new System.Drawing.Point(4, 22);
@@ -103,6 +104,7 @@
             this.TabThirdSheet.Controls.Add(this.lblLayoutText);
             this.TabThirdSheet.Controls.Add(this.pnlUniformStyle);
             this.TabThirdSheet.Controls.Add(this.CbLayoutStyle);
+            this.TabThirdSheet.Controls.Add(this.rbDoubleImages);
             this.TabThirdSheet.Controls.Add(this.lblSelectTsLayout);
             this.TabThirdSheet.Location = new System.Drawing.Point(4, 22);
             this.TabThirdSheet.Name = "TabThirdSheet";
@@ -193,9 +195,21 @@
             this.lblSelectTsLayout.Size = new System.Drawing.Size(98, 13);
             this.lblSelectTsLayout.TabIndex = 0;
             this.lblSelectTsLayout.Text = "Select Layout Style";
-            // 
+            //
+            // rbDoubleImages
+            //
+            this.rbDoubleImages.AutoSize = true;
+            this.rbDoubleImages.Checked = true;
+            this.rbDoubleImages.Location = new System.Drawing.Point(260, 12);
+            this.rbDoubleImages.Name = "rbDoubleImages";
+            this.rbDoubleImages.Size = new System.Drawing.Size(109, 17);
+            this.rbDoubleImages.TabIndex = 2;
+            this.rbDoubleImages.TabStop = true;
+            this.rbDoubleImages.Text = "192 Image Mode";
+            this.rbDoubleImages.UseVisualStyleBackColor = true;
+            //
             // TabNewRoulette
-            // 
+            //
             this.TabNewRoulette.BackColor = System.Drawing.Color.WhiteSmoke;
             this.TabNewRoulette.Controls.Add(this.lblLayoutTextRoulette);
             this.TabNewRoulette.Controls.Add(this.pnlUniformStyleRoulette);
@@ -627,6 +641,7 @@
         private System.Windows.Forms.ToolStripMenuItem aboutToolStripMenuItem;
         private System.Windows.Forms.ComboBox CbLayoutStyle;
         private System.Windows.Forms.Label lblSelectTsLayout;
+        private System.Windows.Forms.RadioButton rbDoubleImages;
         private System.Windows.Forms.Panel pnlUniformStyle;
         private System.Windows.Forms.Label lblBottom;
         private System.Windows.Forms.Label lblTop;

--- a/Form1.cs
+++ b/Form1.cs
@@ -349,15 +349,30 @@ namespace Rutland.PrintFileMaker
                     sfd.InitialDirectory = Settings.DefaultPrintFileFolder;
 
                     ILayout layout;
-                                        
+
+                    bool doubleImages = (this.LayoutType == LayoutType.ThirdSheet && rbDoubleImages.Checked);
 
                     if (this.useSerialNumbers())
                     {
-                        layout = LayoutFactory.GetLayout(LayoutType, true);
+                        if (this.LayoutType == LayoutType.ThirdSheet)
+                        {
+                            layout = new ThirdSheet(true, doubleImages);
+                        }
+                        else
+                        {
+                            layout = LayoutFactory.GetLayout(LayoutType, true);
+                        }
                     }
                     else
                     {
-                        layout = LayoutFactory.GetLayout(LayoutType);
+                        if (this.LayoutType == LayoutType.ThirdSheet)
+                        {
+                            layout = new ThirdSheet(false, doubleImages);
+                        }
+                        else
+                        {
+                            layout = LayoutFactory.GetLayout(LayoutType);
+                        }
                     }
 
                     if (sfd.ShowDialog() == DialogResult.OK)
@@ -405,6 +420,12 @@ namespace Rutland.PrintFileMaker
 
                                 layout.AddImageToRange(imgFile.T1Start, imgFile.T1End, selectedFile);
                                 layout.AddImageToRange(imgFile.T2Start, imgFile.T2End, selectedFile);
+
+                                if (doubleImages)
+                                {
+                                    layout.AddImageToRange(imgFile.T1Start + 96, imgFile.T1End + 96, selectedFile);
+                                    layout.AddImageToRange(imgFile.T2Start + 96, imgFile.T2End + 96, selectedFile);
+                                }
                             }
 
                             //add serial numbers if necessary
@@ -494,8 +515,10 @@ namespace Rutland.PrintFileMaker
 
         private void tabLayoutType_SelectedIndexChanged(object sender, EventArgs e)
         {
+            this.ClearAll();
             this.cmbSelect5x5Layout.SelectedIndex = -1;
             this.CbLayoutStyle.SelectedIndex = -1;
+            this.CbLayoutStyleRoulette.SelectedIndex = -1;
             this.LayoutType = (LayoutType)Enum.ToObject(typeof(LayoutType), tabLayoutType.SelectedIndex);
 
             switch (LayoutType)

--- a/ThirdSheet.cs
+++ b/ThirdSheet.cs
@@ -11,28 +11,30 @@ namespace Rutland.PrintFileMaker
     {
         private int ImageQty;
 
-        public ThirdSheet() : base(96)
+        public ThirdSheet() : this(false, false)
         {
-            this.ImageQty = 96;
         }
 
         public ThirdSheet(bool hasTextContent)
-            : base(96, 48)
+            : this(hasTextContent, false)
         {
-            this.ImageQty = 96;
+        }
+
+        public ThirdSheet(bool hasTextContent, bool doubleImages)
+            : base(doubleImages ? 192 : 96, hasTextContent ? 48 : 0)
+        {
+            this.ImageQty = doubleImages ? 192 : 96;
         }
 
 
         public override void Initialize()
         {
             _Images = new OrderedDictionary();
-            //_Images.Add("default", string.Empty);
 
             for (int i = 1; i <= ImageQty; i++)
             {
                 string newKey = string.Format(VARIABLE_KEY, i);
                 _Images.Add(newKey, base.DefaultImage);
-
             }
 
         }


### PR DESCRIPTION
## Summary
- allow ThirdSheet to support 192 images via new constructor
- add `rbDoubleImages` radio button to the ThirdSheet tab (checked by default)
- duplicate image assignments when the option is enabled

## Testing
- `dotnet test` *(fails: command not found)*