### PR TITLE
Reset controls when changing layout tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+bin/
+obj/
+*.exe
+*.pdb
+*.user
+*.suo

--- a/Form1.cs
+++ b/Form1.cs
@@ -71,6 +71,11 @@ namespace Rutland.PrintFileMaker
             catch (Exception)
             {
                 MessageBox.Show("Please choose your application settings by clicking Edit --> Preferences from the menu bar.");
+
+                // fallback settings so the application remains usable
+                this.Settings = new PfmSettings();
+                this.DefaultImageFile = string.Empty;
+                this.lblDefaultImg.Text = string.Empty;
             }
             
             ClearAll();
@@ -494,8 +499,10 @@ namespace Rutland.PrintFileMaker
 
         private void tabLayoutType_SelectedIndexChanged(object sender, EventArgs e)
         {
+            this.ClearAll();
             this.cmbSelect5x5Layout.SelectedIndex = -1;
             this.CbLayoutStyle.SelectedIndex = -1;
+            this.CbLayoutStyleRoulette.SelectedIndex = -1;
             this.LayoutType = (LayoutType)Enum.ToObject(typeof(LayoutType), tabLayoutType.SelectedIndex);
 
             switch (LayoutType)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-"# Summacutter-Automation" 
+# Summacutter Automation
+
+This repository contains a Windows Forms application for generating print files from image sets.
+
+## Building
+1. Install the .NET Framework 4.x SDK or Visual Studio so that `msbuild` is available.
+2. Open `PrintFileMaker.sln` in Visual Studio or run `msbuild PrintFileMaker.sln` from the command line.
+3. Binaries are produced in the `bin/Debug` or `bin/Release` directories.
+
+Make sure the `PrintFileMaker.exe.config` file remains next to the executable so the application can read its settings.
+
+## Usage
+Run `PrintFileMaker.exe`, choose your layout and images, and use **Edit → Preferences** to set default folders.


### PR DESCRIPTION
## Summary
- clear all panels when switching layout tabs
- reset roulette layout combobox when tab changes
- instantiate fallback settings when config load fails
- ignore build outputs
- document build and usage steps

## Testing
- `dotnet test` *(fails: command not found)*