### PR TITLE
Enable 192 text fields for ThirdSheet layout

### DIFF
--- a/PrintFileMaker.v21 - Copy (2)/PrintFileMaker/PrintFileMaker/Layout.cs
+++ b/PrintFileMaker.v21 - Copy (2)/PrintFileMaker/PrintFileMaker/Layout.cs
@@ -79,23 +79,19 @@ namespace Rutland.PrintFileMaker
                     foreach (DictionaryEntry serialNum in serialNumberSet)
                     {
                         //if serialnumber is blank, set corresponding images to default blank image
-                        if (string.IsNullOrEmpty((serialNum.Value as string).Trim())) 
-                        {                              if (this.FileRefQty == 192) //adjust thirdsheet images 
-                            {                                
-                                //top
-                                string key = string.Format("Variable{0}", Convert.ToString(varNum));
-                                sds.Variables[key] = this.DefaultImage;
-                                //bottom
+                        if (string.IsNullOrEmpty((serialNum.Value as string).Trim()))
+                        {
+                            string key = string.Format("Variable{0}", Convert.ToString(varNum));
+                            sds.Variables[key] = this.DefaultImage;
+
+                            if (this.FileRefQty == 192 && this.TextContentQty == 96)
+                            {
                                 key = string.Format("Variable{0}", Convert.ToString(varNum + 48));
-                                sds.Variables[key] = this.DefaultImage;                                                               
-                            }
-                            else //adjust 5x5 image (-25)
-                            {                                
-                                string key = string.Format("Variable{0}", Convert.ToString(varNum));
                                 sds.Variables[key] = this.DefaultImage;
-                            }                           
-                        }                        //varNum to skip bottoms of 1 - 48
-                        if (varNum == 48 && this.FileRefQty == 192)
+                            }
+                        }
+                        //skip bottom image positions when using 96 text fields
+                        if (varNum == 48 && this.FileRefQty == 192 && this.TextContentQty == 96)
                         {
                             varNum += 48;
                         }

--- a/PrintFileMaker.v21 - Copy (2)/PrintFileMaker/PrintFileMaker/LayoutFactory.cs
+++ b/PrintFileMaker.v21 - Copy (2)/PrintFileMaker/PrintFileMaker/LayoutFactory.cs
@@ -27,10 +27,10 @@ namespace Rutland.PrintFileMaker
             switch (lType)
             {
                 case LayoutType.ThirdSheet:
-                    return new ThirdSheet(true);
+                    return new ThirdSheet(hasSerialNumbers);
 
                 case LayoutType.FiveByFive:
-                    return new FiveByFive(true);
+                    return new FiveByFive(hasSerialNumbers);
 
                 default:
                     throw new Exception("Invalid Layout Type");

--- a/PrintFileMaker.v21 - Copy (2)/PrintFileMaker/PrintFileMaker/ThirdSheet.cs
+++ b/PrintFileMaker.v21 - Copy (2)/PrintFileMaker/PrintFileMaker/ThirdSheet.cs
@@ -9,13 +9,14 @@ namespace Rutland.PrintFileMaker
 {
     public class ThirdSheet : Layout, ILayout
     {
-        private int ImageQty;        public ThirdSheet() : base(192)
+        private int ImageQty;
+
+        public ThirdSheet() : this(false)
         {
-            this.ImageQty = 192;
         }
 
         public ThirdSheet(bool hasTextContent)
-            : base(192, 96)
+            : base(192, hasTextContent ? 192 : 0)
         {
             this.ImageQty = 192;
         }


### PR DESCRIPTION
## Summary
- allow creating `ThirdSheet` layouts with one text field per image
- propagate requested text-field count through `LayoutFactory`
- handle both 96 and 192 text-field cases in `Layout.GeneratePrintFile`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6849df28872c8332b359115ecf007167